### PR TITLE
Updated pa11yci.yml to run the frontend when the check runs #11

### DIFF
--- a/.github/workflows/pa11yci.yml
+++ b/.github/workflows/pa11yci.yml
@@ -24,6 +24,9 @@ jobs:
     - name: Install pa11y-ci
       run: npm install -g pa11y-ci
 
+    - name: Run the application
+      run: npm start & npx wait-on http://localhost:3000
+
     - name: Run pa11y-ci
       run: pa11y-ci
   


### PR DESCRIPTION
Tests were failing to run for new frontend page as the application wasn't being started up. Added npm start to run before running pally to make sure that the actual frontend is there for pa11y to test